### PR TITLE
Hide navigation on start screen

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,7 +19,7 @@ import {
 } from "./assets/icons/Icons";
 
 export default function App() {
-  const [activeNavItem, setActiveNavItem] = React.useState("Home");
+  const [activeNavItem, setActiveNavItem] = React.useState("");
   return (
     <Router>
       <GlobalStyle />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,7 +19,7 @@ import {
 } from "./assets/icons/Icons";
 
 export default function App() {
-  const [activeNavItem, setActiveNavItem] = React.useState("");
+  const [activeNavItem, setActiveNavItem] = React.useState("Home");
 
   return (
     <Router>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,12 +20,44 @@ import {
 
 export default function App() {
   const [activeNavItem, setActiveNavItem] = React.useState("");
+
   return (
     <Router>
       <GlobalStyle />
       <Main>
+        <Route exact path="/" component={Start} />
+        <Route
+          path="/(.+)"
+          render={() => (
+            <TabNavigation
+              links={[
+                {
+                  label: "Home",
+                  Icon: HomeIcon,
+                  id: "home",
+                },
+                {
+                  label: "Konzerte",
+                  Icon: KonzerteIcon,
+                  id: "concerts",
+                },
+                {
+                  label: "Nachrichten",
+                  Icon: MessagesIcon,
+                  id: "messages",
+                },
+                {
+                  label: "Profil",
+                  Icon: ProfilIcon,
+                  id: "profile",
+                },
+              ]}
+              value={activeNavItem}
+              onItemClick={(item) => setActiveNavItem(item)}
+            />
+          )}
+        />
         <Switch>
-          <Route exact path="/" component={Start} />
           <Route path="/home" component={Home} />
           <Route exact path="/concerts" component={Concerts} />
           <Route path="/newconcert" component={NewConcert} />
@@ -34,32 +66,6 @@ export default function App() {
           <Route path="/profile" component={Profile} />
         </Switch>
       </Main>
-      <TabNavigation
-        links={[
-          {
-            label: "Home",
-            Icon: HomeIcon,
-            id: "home",
-          },
-          {
-            label: "Konzerte",
-            Icon: KonzerteIcon,
-            id: "concerts",
-          },
-          {
-            label: "Nachrichten",
-            Icon: MessagesIcon,
-            id: "messages",
-          },
-          {
-            label: "Profil",
-            Icon: ProfilIcon,
-            id: "profile",
-          },
-        ]}
-        value={activeNavItem}
-        onItemClick={(item) => setActiveNavItem(item)}
-      />
     </Router>
   );
 }

--- a/client/src/pages/Start.js
+++ b/client/src/pages/Start.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { Redirect } from "react-router-dom";
+
 import { ButtonFull } from "../components/buttons/ButtonFull";
 import { ButtonOutline } from "../components/buttons/ButtonOutline";
 import { ButtonContainer } from "../components/buttons/ButtonContainer";
@@ -8,8 +10,15 @@ import { IntroductionText } from "../components/textStyling/IntroductionText";
 import { IntroductionHeading } from "../components/textStyling/IntroductionHeading";
 
 export default function Start() {
+  const [redirect, setRedirect] = React.useState(false);
+
+  function redirectToHome() {
+    setTimeout(() => setRedirect(true), 4000);
+  }
+  redirectToHome();
   return (
     <>
+      {redirect ? <Redirect to="/home" /> : true}
       <AnimatedLogo />
       <TextContainer>
         <IntroductionHeading>


### PR DESCRIPTION
Navigation should only visible after login. As for now, there is no login/signup, so I add a redirect to home screen after a short timeout.